### PR TITLE
Eyepiece API production support and cleanup (#20)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "VITE_API_URL=$DEPLOY_PRIME_URL vite build"
+  command = "vite build"
   dir = "dist/client"
 [dev]
   command = "vite dev"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,13 +1,16 @@
 import type { ReactNode } from 'react'
 import { ThemeProvider } from '@/components/theme/theme-provider'
 import { AuthProvider } from '@/features/auth/auth-provider'
+import { EyepieceClientProvider } from '@/lib/api/eyepiece/eyepiece-client-provider'
 import { RouterProvider } from '@/integrations/react-aria-components/router-provider'
 
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <AuthProvider>
       <RouterProvider>
-        <ThemeProvider>{children}</ThemeProvider>
+        <EyepieceClientProvider>
+          <ThemeProvider>{children}</ThemeProvider>
+        </EyepieceClientProvider>
       </RouterProvider>
     </AuthProvider>
   )

--- a/src/features/assets/api/asset-queries.ts
+++ b/src/features/assets/api/asset-queries.ts
@@ -1,28 +1,28 @@
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { getAsset, getMetadata } from '@/lib/api/eyepiece/client'
+import type { EyepieceClient } from '@/lib/api/eyepiece/client'
 
 type AssetCacheKey = ['assets', string]
 
-export function getAssetOptions(id: string) {
+export function getAssetOptions(client: EyepieceClient, id: string) {
   return queryOptions({
-    queryKey: ['assets', id] as AssetCacheKey,
+    queryKey: ['assets', id] as const satisfies AssetCacheKey,
     queryFn: ({ queryKey }) => {
-      return getAsset(queryKey[1])
+      return client.getAsset(queryKey[1])
     },
   })
 }
 
-export function useAsset(id: string) {
-  return useQuery(getAssetOptions(id))
+export function useAsset(client: EyepieceClient, id: string) {
+  return useQuery(getAssetOptions(client, id))
 }
 
 type MetadataCacheKey = ['assets', string, 'metadata']
 
-export function getMetadataOptions(id: string) {
+export function getMetadataOptions(client: EyepieceClient, id: string) {
   return queryOptions({
-    queryKey: ['assets', id, 'metadata'] as MetadataCacheKey,
+    queryKey: ['assets', id, 'metadata'] as const satisfies MetadataCacheKey,
     queryFn: ({ queryKey }) => {
-      return getMetadata(queryKey[1])
+      return client.getMetadata(queryKey[1])
     },
     staleTime: Infinity,
     refetchOnMount: false,
@@ -30,9 +30,13 @@ export function getMetadataOptions(id: string) {
   })
 }
 
-export function useMetadata(id: string, enabled?: boolean) {
+export function useMetadata(
+  client: EyepieceClient,
+  id: string,
+  enabled?: boolean,
+) {
   return useQuery({
-    ...getMetadataOptions(id),
+    ...getMetadataOptions(client, id),
     enabled,
   })
 }

--- a/src/features/listing/item-grid/hybrid-grid.tsx
+++ b/src/features/listing/item-grid/hybrid-grid.tsx
@@ -10,14 +10,12 @@ import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 export function HybridGrid<T extends GridItem>({
   children,
   items,
-  navigateToDetail,
   gap = 12,
   minTileWidth = 200,
   ...props
 }: Omit<ComponentPropsWithoutRef<'div'>, 'children'> & {
   children: (item: T, itemProps: HybridGridItemProvidedProps<T>) => ReactNode
   items: Array<T>
-  navigateToDetail: (id: string) => void
   gap?: number
   minTileWidth?: number
 }) {

--- a/src/features/search/api/search-queries.ts
+++ b/src/features/search/api/search-queries.ts
@@ -1,22 +1,24 @@
 import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
 import type { InfiniteData } from '@tanstack/react-query'
 import type { EyepiecePageSearchParams } from '@/lib/api/eyepiece/types'
-import { flattenAssetsSelector, searchImages } from '@/lib/api/eyepiece/client'
+import type { EyepieceClient } from '@/lib/api/eyepiece/client'
+import { flattenAssetsSelector } from '@/lib/api/eyepiece/client'
 
 type SearchCacheKey = ['search', EyepiecePageSearchParams]
 
-export function searchImagesOptions<
-  TSelectData = InfiniteData<Awaited<ReturnType<typeof searchImages>>, number>,
->(
+type SearchImagesFn = EyepieceClient['searchImages']
+type SearchImagesPage = Awaited<ReturnType<SearchImagesFn>>
+type SearchImagesInfinite = InfiniteData<SearchImagesPage, number>
+
+export function searchImagesOptions<TSelectData = SearchImagesInfinite>(
+  client: EyepieceClient,
   params: EyepiecePageSearchParams,
-  select?: (
-    data: InfiniteData<Awaited<ReturnType<typeof searchImages>>, number>,
-  ) => TSelectData,
+  select?: (data: SearchImagesInfinite) => TSelectData,
 ) {
   return infiniteQueryOptions({
-    queryKey: ['search', params] as SearchCacheKey,
+    queryKey: ['search', params] as const satisfies SearchCacheKey,
     queryFn: ({ queryKey, pageParam = 1 }) =>
-      searchImages({ ...queryKey[1], page: pageParam }),
+      client.searchImages({ ...queryKey[1], page: pageParam }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.pagination.next,
     staleTime: 1000 * 60 * 5,
@@ -24,6 +26,11 @@ export function searchImagesOptions<
   })
 }
 
-export function useSearchResults(params: EyepiecePageSearchParams) {
-  return useInfiniteQuery(searchImagesOptions(params, flattenAssetsSelector))
+export function useSearchResults(
+  client: EyepieceClient,
+  params: EyepiecePageSearchParams,
+) {
+  return useInfiniteQuery(
+    searchImagesOptions(client, params, flattenAssetsSelector),
+  )
 }

--- a/src/lib/api/eyepiece/album-queries.ts
+++ b/src/lib/api/eyepiece/album-queries.ts
@@ -1,21 +1,23 @@
 import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
-import { flattenAssetsSelector, getAlbum } from './client'
+import { flattenAssetsSelector } from './client'
+import type { EyepieceClient } from './client'
 import type { InfiniteData } from '@tanstack/react-query'
 
 type AlbumCacheKey = ['albums', string]
 
-export function getAlbumOptions<
-  TSelectData = InfiniteData<Awaited<ReturnType<typeof getAlbum>>, number>,
->(
+type GetAlbumFn = EyepieceClient['getAlbum']
+type AlbumPage = Awaited<ReturnType<GetAlbumFn>>
+type AlbumInfinite = InfiniteData<AlbumPage, number>
+
+export function getAlbumOptions<TSelectData = AlbumInfinite>(
+  client: EyepieceClient,
   id: string,
-  select?: (
-    data: InfiniteData<Awaited<ReturnType<typeof getAlbum>>, number>,
-  ) => TSelectData,
+  select?: (data: AlbumInfinite) => TSelectData,
 ) {
   return infiniteQueryOptions({
-    queryKey: ['albums', id] as AlbumCacheKey,
+    queryKey: ['albums', id] as const satisfies AlbumCacheKey,
     queryFn: ({ queryKey, pageParam = 1 }) => {
-      return getAlbum(queryKey[1], { page: pageParam })
+      return client.getAlbum(queryKey[1], { page: pageParam })
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.pagination.next,
@@ -23,6 +25,6 @@ export function getAlbumOptions<
   })
 }
 
-export function useAlbumAssets(id: string) {
-  return useInfiniteQuery(getAlbumOptions(id, flattenAssetsSelector))
+export function useAlbumAssets(client: EyepieceClient, id: string) {
+  return useInfiniteQuery(getAlbumOptions(client, id, flattenAssetsSelector))
 }

--- a/src/lib/api/eyepiece/client.ts
+++ b/src/lib/api/eyepiece/client.ts
@@ -7,13 +7,11 @@ import {
 import type {
   EyepieceApiAlbumParams,
   EyepieceApiSearchParams,
+  EyepieceAssetCollectionResponse,
   EyepieceAssetItem,
+  EyepieceMetadata,
 } from './types'
 import type { InfiniteData } from '@tanstack/react-query'
-
-const API_HOST = import.meta.env.SSR
-  ? import.meta.env.VITE_API_URL || 'http://localhost:3000'
-  : ''
 
 export function flattenAssetsSelector<
   TData extends { assets: Array<EyepieceAssetItem> },
@@ -24,45 +22,85 @@ export function flattenAssetsSelector<
   }
 }
 
-export async function getAlbum(
-  id: string,
-  params: EyepieceApiAlbumParams = {},
-) {
-  const res = await fetch(
-    `${API_HOST}/api/albums/${id}${defaultStringifySearch(params)}`,
-  )
-  if (!res.ok) {
-    throw new Error(`Error fetching album: ${res.statusText}`)
+function assertSsrHasOrigin(origin: string, path: string) {
+  if (import.meta.env.SSR && !origin) {
+    throw new Error(
+      [
+        `SSR attempted to fetch a relative URL (${path}) without an origin.`,
+        `This usually means the route loader didn't preload the query with an origin-aware client.`,
+        `Fix: preload this query in the route loader using origin = location.url.origin.`,
+      ].join('\n'),
+    )
   }
-  const data = await res.json()
-  return eyepieceAssetCollectionResponseSchema.parse(data)
 }
 
-export async function getAsset(id: string) {
-  const res = await fetch(`${API_HOST}/api/asset/${id}`)
-  if (!res.ok) {
-    throw new Error(`Error fetching asset: ${res.statusText}`)
-  }
-  const data = await res.json()
-  return eyepieceAssetItemSchema.parse(data)
+type EyepieceClientOptions = { origin?: string }
+
+export type EyepieceClient = {
+  getAsset: (id: string) => Promise<EyepieceAssetItem>
+  getAlbum: (
+    id: string,
+    params?: EyepieceApiAlbumParams,
+  ) => Promise<EyepieceAssetCollectionResponse>
+  getMetadata: (id: string) => Promise<EyepieceMetadata>
+  searchImages: (
+    params: EyepieceApiSearchParams,
+  ) => Promise<EyepieceAssetCollectionResponse>
 }
 
-export async function getMetadata(id: string) {
-  const res = await fetch(`${API_HOST}/api/asset/${id}/metadata`)
-  if (!res.ok) {
-    throw new Error(`Error fetching asset metadata: ${res.statusText}`)
+export function createEyepieceClient({
+  origin = '',
+}: EyepieceClientOptions = {}): EyepieceClient {
+  const withOrigin = (path: string) => {
+    if (!path.startsWith('/')) {
+      throw new Error(`API path must start with "/": ${path}`)
+    }
+    assertSsrHasOrigin(origin, path)
+    return `${origin}${path}`
   }
-  const data = await res.json()
-  return eyepieceMetadataSchema.parse(data)
-}
 
-export async function searchImages(params: EyepieceApiSearchParams) {
-  const res = await fetch(
-    `${API_HOST}/api/search${defaultStringifySearch(params)}`,
-  )
-  if (!res.ok) {
-    throw new Error(`Error searching assets: ${res.statusText}`)
+  return {
+    getAlbum: async function getAlbum(
+      id: string,
+      params: EyepieceApiAlbumParams = {},
+    ) {
+      const res = await fetch(
+        withOrigin(`/api/albums/${id}${defaultStringifySearch(params)}`),
+      )
+      if (!res.ok) {
+        throw new Error(`Error fetching album: ${res.statusText}`)
+      }
+      const data = await res.json()
+      return eyepieceAssetCollectionResponseSchema.parse(data)
+    },
+
+    getAsset: async function getAsset(id: string) {
+      const res = await fetch(withOrigin(`/api/asset/${id}`))
+      if (!res.ok) {
+        throw new Error(`Error fetching asset: ${res.statusText}`)
+      }
+      const data = await res.json()
+      return eyepieceAssetItemSchema.parse(data)
+    },
+
+    getMetadata: async function getMetadata(id: string) {
+      const res = await fetch(withOrigin(`/api/asset/${id}/metadata`))
+      if (!res.ok) {
+        throw new Error(`Error fetching asset metadata: ${res.statusText}`)
+      }
+      const data = await res.json()
+      return eyepieceMetadataSchema.parse(data)
+    },
+
+    searchImages: async function searchImages(params: EyepieceApiSearchParams) {
+      const res = await fetch(
+        withOrigin(`/api/search${defaultStringifySearch(params)}`),
+      )
+      if (!res.ok) {
+        throw new Error(`Error searching assets: ${res.statusText}`)
+      }
+      const data = await res.json()
+      return eyepieceAssetCollectionResponseSchema.parse(data)
+    },
   }
-  const data = await res.json()
-  return eyepieceAssetCollectionResponseSchema.parse(data)
 }

--- a/src/lib/api/eyepiece/eyepiece-client-provider.tsx
+++ b/src/lib/api/eyepiece/eyepiece-client-provider.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useMemo } from 'react'
+import { createEyepieceClient } from './client'
+import type { EyepieceClient } from './client'
+import type { ReactNode } from 'react'
+
+const EyepieceClientContext = createContext<EyepieceClient | null>(null)
+
+export function EyepieceClientProvider({ children }: { children: ReactNode }) {
+  const client = useMemo(() => createEyepieceClient({ origin: '' }), [])
+
+  return (
+    <EyepieceClientContext.Provider value={client}>
+      {children}
+    </EyepieceClientContext.Provider>
+  )
+}
+
+export function useEyepieceClient() {
+  const client = useContext(EyepieceClientContext)
+  if (!client) throw new Error('EyepieceClientProvider missing')
+  return client
+}

--- a/src/routes/(pages)/(search)/-components/search-results.tsx
+++ b/src/routes/(pages)/(search)/-components/search-results.tsx
@@ -13,6 +13,7 @@ import {
   ItemGridSkeleton,
 } from '@/features/listing/item-grid/hybrid-grid'
 import { HybridGridItem } from '@/features/listing/item-grid/hybrid-grid-item'
+import { useEyepieceClient } from '@/lib/api/eyepiece/eyepiece-client-provider'
 
 interface SearchResultsProps {
   searchParams: EyepiecePageSearchParams
@@ -20,6 +21,7 @@ interface SearchResultsProps {
 
 export function SearchResults({ searchParams }: SearchResultsProps) {
   const navigate = useNavigate()
+  const client = useEyepieceClient()
   const {
     data,
     isPending,
@@ -28,7 +30,7 @@ export function SearchResults({ searchParams }: SearchResultsProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useSearchResults(searchParams)
+  } = useSearchResults(client, searchParams)
 
   const uiResetKey = useMemo(
     () => paramsToUiResetKey(searchParams),

--- a/src/routes/(pages)/(search)/index.tsx
+++ b/src/routes/(pages)/(search)/index.tsx
@@ -9,6 +9,7 @@ import { hasSearchFields } from '@/lib/api/eyepiece/util'
 import { SearchBar } from '@/features/search/components/search-bar'
 import { searchImagesOptions } from '@/features/search/api/search-queries'
 import { getTitleText } from '@/lib/util'
+import { createEyepieceClient } from '@/lib/api/eyepiece/client'
 
 const NO_SEARCH_TITLE = 'Search NASA Images and Videos'
 
@@ -22,10 +23,13 @@ export const Route = createFileRoute('/(pages)/(search)/')({
       return {}
     }
   },
-  loader: ({ context, deps: { search } }) => {
+  loader: ({ location, context, deps: { search } }) => {
     if (search) {
+      const client = createEyepieceClient({
+        origin: location.url.origin,
+      })
       return context.queryClient.ensureInfiniteQueryData(
-        searchImagesOptions(search),
+        searchImagesOptions(client, search),
       )
     }
   },

--- a/src/routes/(pages)/albums/$albumId.tsx
+++ b/src/routes/(pages)/albums/$albumId.tsx
@@ -2,13 +2,18 @@ import { createFileRoute } from '@tanstack/react-router'
 import { AlbumAssets } from './-components/album-assets'
 import { getAlbumOptions } from '@/lib/api/eyepiece/album-queries'
 import { getTitleText } from '@/lib/util'
+import { createEyepieceClient } from '@/lib/api/eyepiece/client'
 
 export const Route = createFileRoute('/(pages)/albums/$albumId')({
   component: AlbumView,
-  loader: ({ context, params }) =>
-    context.queryClient.ensureInfiniteQueryData(
-      getAlbumOptions(params.albumId),
-    ),
+  loader: ({ context, location, params }) => {
+    const client = createEyepieceClient({
+      origin: location.url.origin,
+    })
+    return context.queryClient.ensureInfiniteQueryData(
+      getAlbumOptions(client, params.albumId),
+    )
+  },
   head: ({ params }) => ({
     meta: [{ title: getTitleText(`${params.albumId} Media`) }],
   }),

--- a/src/routes/(pages)/albums/-components/album-assets.tsx
+++ b/src/routes/(pages)/albums/-components/album-assets.tsx
@@ -12,12 +12,14 @@ import {
 } from '@/features/assets/components/asset-tile'
 import { useAlbumAssets } from '@/lib/api/eyepiece/album-queries'
 import { HybridGridItem } from '@/features/listing/item-grid/hybrid-grid-item'
+import { useEyepieceClient } from '@/lib/api/eyepiece/eyepiece-client-provider'
 
 export interface AlbumAssetsProps {
   albumId: string
 }
 
 export function AlbumAssets({ albumId }: AlbumAssetsProps) {
+  const client = useEyepieceClient()
   const {
     data,
     isPending,
@@ -26,7 +28,7 @@ export function AlbumAssets({ albumId }: AlbumAssetsProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useAlbumAssets(albumId)
+  } = useAlbumAssets(client, albumId)
   const navigate = useNavigate()
 
   const uiResetKey = useMemo(() => paramsToUiResetKey({ albumId }), [albumId])

--- a/src/routes/(pages)/assets/$assetId.tsx
+++ b/src/routes/(pages)/assets/$assetId.tsx
@@ -4,11 +4,19 @@ import { MetadataButton } from './-components/metadata/button'
 import { NOT_FOUND_IMAGE, getTitleText } from '@/lib/util'
 import { getAssetOptions, useAsset } from '@/features/assets/api/asset-queries'
 import { Link } from '@/components/ui/link'
+import { useEyepieceClient } from '@/lib/api/eyepiece/eyepiece-client-provider'
+import { createEyepieceClient } from '@/lib/api/eyepiece/client'
 
 export const Route = createFileRoute('/(pages)/assets/$assetId')({
   component: AssetView,
-  loader: ({ context, params }) =>
-    context.queryClient.ensureQueryData(getAssetOptions(params.assetId)),
+  loader: ({ context, location, params }) => {
+    const client = createEyepieceClient({
+      origin: location.url.origin,
+    })
+    return context.queryClient.ensureQueryData(
+      getAssetOptions(client, params.assetId),
+    )
+  },
   head: ({ loaderData }) => ({
     meta: [{ title: getTitleText(loaderData?.title || 'NASA Media') }],
   }),
@@ -16,7 +24,8 @@ export const Route = createFileRoute('/(pages)/assets/$assetId')({
 
 export function AssetView() {
   const { assetId } = Route.useParams()
-  const { data, isPending, isError, error } = useAsset(assetId)
+  const client = useEyepieceClient()
+  const { data, isPending, isError, error } = useAsset(client, assetId)
   const returnUrl = useRouterState({
     select: (s) => s.resolvedLocation?.state.returnUrl,
   })

--- a/src/routes/(pages)/assets/-components/metadata/button.tsx
+++ b/src/routes/(pages)/assets/-components/metadata/button.tsx
@@ -1,16 +1,18 @@
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { Button } from 'react-aria-components'
 import { useQueryClient } from '@tanstack/react-query'
 import { InfoIcon } from '@phosphor-icons/react/dist/ssr'
 import { useCallback } from 'react'
 import { MetadataModal } from './modal'
+import { Button } from '@/components/ui/button'
 import { getMetadataOptions } from '@/features/assets/api/asset-queries'
+import { useEyepieceClient } from '@/lib/api/eyepiece/eyepiece-client-provider'
 
 const METADATA_HASH = 'metadata'
 
 export function MetadataButton({ id }: { id: string }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const eyepieceClient = useEyepieceClient()
 
   const isOpen = useRouterState({
     select: (s) => s.location.hash === METADATA_HASH,
@@ -23,7 +25,7 @@ export function MetadataButton({ id }: { id: string }) {
 
   const prefetch = useCallback(() => {
     // NOTE: this gets spammed on every hover/focus/press - add throttle if staleTime is removed
-    void queryClient.prefetchQuery(getMetadataOptions(id))
+    void queryClient.prefetchQuery(getMetadataOptions(eyepieceClient, id))
   }, [queryClient, id])
   return (
     <>
@@ -38,18 +40,13 @@ export function MetadataButton({ id }: { id: string }) {
           border: 'none',
           padding: 0,
           margin: 0,
-          cursor: 'pointer',
-          outline: 'none',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
         }}
       >
         <InfoIcon size={24} color="white" />
       </Button>
 
       <MetadataModal
-        id={id}
+        assetId={id}
         isOpen={isOpen}
         onOpenChange={(shouldOpen: boolean) => (shouldOpen ? open() : close())}
       />

--- a/src/routes/(pages)/assets/-components/metadata/modal.tsx
+++ b/src/routes/(pages)/assets/-components/metadata/modal.tsx
@@ -1,85 +1,32 @@
-import { XIcon } from '@phosphor-icons/react/dist/ssr'
-import {
-  Button,
-  Dialog,
-  Heading,
-  Modal,
-  ModalOverlay,
-} from 'react-aria-components'
+import { Button } from 'react-aria-components'
 import type { ComponentPropsWithoutRef } from 'react'
 import { MetadataTable } from '@/features/assets/components/metadata'
 import { useMetadata } from '@/features/assets/api/asset-queries'
+import { ModalDialog } from '@/components/ui/modal-dialog'
+import { useEyepieceClient } from '@/lib/api/eyepiece/eyepiece-client-provider'
 
 export function MetadataModal({
-  id,
+  assetId,
   isOpen,
   onOpenChange,
 }: {
-  id: string
+  assetId: string
   isOpen: boolean
   onOpenChange: (open: boolean) => void
 }) {
   return (
-    <ModalOverlay
+    <ModalDialog
       isOpen={isOpen}
       onOpenChange={onOpenChange}
+      title="Metadata"
       isDismissable
-      css={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: Infinity,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-      }}
     >
-      <Modal css={{ height: '100%', padding: '2rem' }}>
-        <Dialog
-          aria-labelledby="metadata-title"
-          css={{
-            backgroundColor: 'var(--background)',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '1rem',
-            height: '100%',
-            margin: '0 auto',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              gap: 12,
-              alignItems: 'center',
-              padding: '2rem',
-            }}
-          >
-            <Heading id="metadata-title" slot="title">
-              Metadata
-            </Heading>
-
-            <Button
-              aria-label="Close metadata dialog"
-              onPress={() => onOpenChange(false)}
-              css={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                width: 32,
-                height: 32,
-                cursor: 'pointer',
-                justifyContent: 'center',
-              }}
-            >
-              <XIcon />
-            </Button>
-          </div>
-
-          <MetadataModalContent
-            assetId={id}
-            isOpen={isOpen}
-            css={{ minHeight: 0, overflowY: 'auto', padding: '2rem' }}
-          />
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
+      <MetadataModalContent
+        assetId={assetId}
+        isOpen={isOpen}
+        css={{ minHeight: 0, overflowY: 'auto', padding: '2rem' }}
+      />
+    </ModalDialog>
   )
 }
 
@@ -91,7 +38,12 @@ function MetadataModalContent({
   assetId: string
   isOpen: boolean
 }) {
-  const { data, isLoading, isError, refetch } = useMetadata(assetId, isOpen)
+  const eyepieceClient = useEyepieceClient()
+  const { data, isLoading, isError, refetch } = useMetadata(
+    eyepieceClient,
+    assetId,
+    isOpen,
+  )
 
   if (isLoading)
     return (

--- a/src/routes/api/search.ts
+++ b/src/routes/api/search.ts
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { calculateNextPage } from './-util'
 import type { NasaSearchParams } from '@/server/lib/nasa-images/types'
 import type {
@@ -18,15 +17,11 @@ export const Route = createFileRoute('/api/search')({
   server: {
     middleware: [buildUrlSearchParamsMiddleware(eyepieceApiSearchParamsSchema)],
     handlers: {
-      GET: async ({ context }) => {
+      GET: async ({ context: { searchParams } }) => {
         const pagination = eyepiecePaginationSchema.parse({
-          page: context.searchParams.page,
-          pageSize: context.searchParams.pageSize,
+          page: searchParams.page,
+          pageSize: searchParams.pageSize,
         })
-        const searchParams = {
-          ...context.searchParams,
-          ...pagination,
-        }
         const nasaSearchParams = eyepieceToNasaSearchParams(searchParams)
         const nasaResponse = await search(nasaSearchParams)
         const assets = nasaResponse.collection.items.map(mapMediaItem)
@@ -36,7 +31,7 @@ export const Route = createFileRoute('/api/search')({
           assets,
           pagination: { next, total },
         }
-        return json(response)
+        return Response.json(response)
       },
     },
   },

--- a/src/server/lib/middleware.ts
+++ b/src/server/lib/middleware.ts
@@ -1,4 +1,4 @@
-import { createMiddleware, json } from '@tanstack/react-start'
+import { createMiddleware } from '@tanstack/react-start'
 import z from 'zod'
 
 export function buildUrlSearchParamsMiddleware<T extends z.ZodType>(schema: T) {
@@ -9,7 +9,10 @@ export function buildUrlSearchParamsMiddleware<T extends z.ZodType>(schema: T) {
     )
 
     if (!result.success) {
-      return json({ error: z.treeifyError(result.error) }, { status: 400 })
+      return Response.json(
+        { error: z.treeifyError(result.error) },
+        { status: 400 },
+      )
     }
 
     return next({


### PR DESCRIPTION
* stop using VITE_API_URL=$DEPLOY_PRIME_URL for API
* use location.url.origin during SSR
* create client wrapper to configure this
* pass client via provider
* use `Response.json` instead of deprecated `json`