### PR TITLE
bug: force scrollbar-gutter stable both-edges

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5,7 +5,8 @@
 }
 
 html {
-  scrollbar-gutter: stable both-edges;
+  /* react aria sets stable (not stable both-edges) which causes a jump in layout when a popover shows */
+  scrollbar-gutter: stable both-edges !important;
 }
 
 body {


### PR DESCRIPTION
React Aria Popover uses stable without both-edges via JS.
That caused a shift on vertically overflowing pages on popover open