### PR TITLE
restrict ambiguous imports (#24)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,54 @@
 import { tanstackConfig } from '@tanstack/eslint-config'
 import queryPlugin from '@tanstack/eslint-plugin-query'
 
-export default [...tanstackConfig, ...queryPlugin.configs['flat/recommended']]
+export default [
+  ...tanstackConfig,
+  ...queryPlugin.configs['flat/recommended'],
+  {
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['useId'],
+              message: 'Import useId from "react-aria" instead of "react".',
+            },
+            {
+              name: 'react-aria-components',
+              message:
+                'Import from our UI layer (e.g. "@/components/ui/forms") instead of directly from react-aria-components.',
+            },
+          ],
+          patterns: [
+            {
+              group: ['react-aria-components/*'],
+              message:
+                'Import from our UI layer (e.g. "@/components/ui/forms") instead of directly from react-aria-components.',
+            },
+            {
+              group: [
+                '../**/components/ui',
+                '../**/components/ui/*',
+                './**/components/ui',
+                './**/components/ui/*',
+              ],
+              message:
+                'Import UI via "@/components/ui/…" instead of relative paths.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      'src/components/ui/**/*.{ts,tsx}',
+      'src/integrations/react-aria-components/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-imports': 'off',
+    },
+  },
+]

--- a/src/components/theme/theme-toggle-button.tsx
+++ b/src/components/theme/theme-toggle-button.tsx
@@ -1,4 +1,3 @@
-import { Switch } from 'react-aria-components'
 import {
   MoonStarsIcon,
   SunIcon,
@@ -7,7 +6,8 @@ import {
 } from '@phosphor-icons/react/dist/ssr'
 import { Form } from '../ui/forms'
 import { useThemeToggle } from './theme-provider'
-import type { SwitchProps } from 'react-aria-components'
+import type { SwitchProps } from '@/components/ui/switch'
+import { Switch } from '@/components/ui/switch'
 
 const ThemeToggleButton = (props: SwitchProps) => {
   const { theme, toggleTheme } = useThemeToggle()

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,7 @@
 import { Button as ReactAriaButton } from 'react-aria-components'
-import type { ButtonVariant } from './types'
 import type { ButtonProps as RacButtonProps } from 'react-aria-components'
 
-export const buttonCss = {
+const buttonCss = {
   border: 'none',
   padding: '0.5rem 1rem',
   borderRadius: '4px',
@@ -20,24 +19,28 @@ export const buttonCss = {
   },
 }
 
-export const getButtonVariantStyles = (variant: ButtonVariant) => {
-  return {
-    backgroundColor:
-      variant === 'primary' ? 'var(--primary-bg)' : 'var(--secondary-bg)',
-    color:
-      variant === 'primary' ? 'var(--primary-text)' : 'var(--secondary-text)',
-  }
+const primaryCss = {
+  backgroundColor: 'var(--primary-bg)',
+  color: 'var(--primary-text)',
+  '&[data-disabled]': { color: 'var(--primary-text-muted)' },
 }
 
-type ButtonProps = RacButtonProps & {
+const secondaryCss = {
+  backgroundColor: 'var(--secondary-bg)',
+  color: 'var(--secondary-text)',
+  '&[data-disabled]': { color: 'var(--primary-text-muted)' },
+}
+
+type ButtonVariant = 'primary' | 'secondary'
+
+export type ButtonProps = RacButtonProps & {
   variant?: ButtonVariant
 }
 
 export function Button({ variant = 'secondary', ...props }: ButtonProps) {
   return (
     <ReactAriaButton
-      css={buttonCss}
-      style={getButtonVariantStyles(variant)}
+      css={[buttonCss, variant === 'primary' ? primaryCss : secondaryCss]}
       {...props}
     />
   )

--- a/src/components/ui/forms.tsx
+++ b/src/components/ui/forms.tsx
@@ -20,6 +20,8 @@ import type {
   TextFieldProps as RacTextFieldProps,
 } from 'react-aria-components'
 
+export { FieldError, Input, Label }
+
 export type { FormState, FormErrorState } from './forms.types'
 
 export function FormErrors({ errors = [] }: { errors?: Array<string> }) {

--- a/src/components/ui/i18n.tsx
+++ b/src/components/ui/i18n.tsx
@@ -1,0 +1,1 @@
+export { VisuallyHidden } from 'react-aria-components'

--- a/src/components/ui/list-box.tsx
+++ b/src/components/ui/list-box.tsx
@@ -1,0 +1,1 @@
+export { ListBox, ListBoxItem } from 'react-aria-components'

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,1 @@
+export { Popover } from 'react-aria-components'

--- a/src/components/ui/search-field.tsx
+++ b/src/components/ui/search-field.tsx
@@ -1,0 +1,2 @@
+export type { SearchFieldProps } from 'react-aria-components'
+export { SearchField } from 'react-aria-components'

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,2 @@
+export type { SelectProps, Key as SelectKey } from 'react-aria-components'
+export { Select, SelectValue } from 'react-aria-components'

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,7 @@
+export type { SliderProps } from 'react-aria-components'
+export {
+  Slider,
+  SliderOutput,
+  SliderThumb,
+  SliderTrack,
+} from 'react-aria-components'

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,2 @@
+export type { SwitchProps } from 'react-aria-components'
+export { Switch } from 'react-aria-components'

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -1,0 +1,1 @@
+export { Text } from 'react-aria-components'

--- a/src/components/ui/toggle-button.tsx
+++ b/src/components/ui/toggle-button.tsx
@@ -1,0 +1,2 @@
+export type { ToggleButtonProps } from 'react-aria-components'
+export { ToggleButton } from 'react-aria-components'

--- a/src/components/ui/types.ts
+++ b/src/components/ui/types.ts
@@ -1,1 +1,0 @@
-export type ButtonVariant = 'primary' | 'secondary'

--- a/src/features/listing/infinite-loader/infinite-loader.tsx
+++ b/src/features/listing/infinite-loader/infinite-loader.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react'
-import { VisuallyHidden } from 'react-aria-components'
 import { useInfiniteStatus } from './hooks/use-infinite-status'
 import { useLoadMoreController } from './hooks/use-load-more-controller'
 import { LoadMoreButton } from './load-more-button'
 import type { ComponentPropsWithoutRef } from 'react'
+import { VisuallyHidden } from '@/components/ui/i18n'
 
 export function InfiniteLoader({
   children,

--- a/src/features/search/components/search-bar/date-button.tsx
+++ b/src/features/search/components/search-bar/date-button.tsx
@@ -3,8 +3,8 @@ import {
   CalendarMinusIcon,
   CalendarPlusIcon,
 } from '@phosphor-icons/react/dist/ssr'
-import { ToggleButton } from 'react-aria-components'
-import type { ToggleButtonProps } from 'react-aria-components'
+import type { ToggleButtonProps } from '@/components/ui/toggle-button'
+import { ToggleButton } from '@/components/ui/toggle-button'
 
 export function DateButton(props: ToggleButtonProps) {
   return (

--- a/src/features/search/components/search-bar/index.tsx
+++ b/src/features/search/components/search-bar/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { Form } from 'react-aria-components'
 import { useNavigate } from '@tanstack/react-router'
 import { DateButton } from './date-button'
 import {
@@ -10,9 +9,10 @@ import {
 } from './media-type-field'
 import { SubmitButton } from './submit-button'
 import { YearRangeSlider } from './year-range-slider'
-import { SearchField } from './search-field'
-import type { FormProps } from 'react-aria-components'
+import { SearchInput } from './search-input'
+import type { FormProps } from '@/components/ui/forms'
 import type { EyepieceMedia } from '@/lib/api/eyepiece/types'
+import { Form } from '@/components/ui/forms'
 import { YEAR_MAX, YEAR_MIN } from '@/lib/api/eyepiece/types'
 
 interface SearchBarProps extends FormProps {
@@ -97,7 +97,7 @@ export function SearchBar({
           items={MEDIA_TYPES}
           popoverFontSize={fontSize}
         />
-        <SearchField
+        <SearchInput
           aria-label="Keywords"
           value={searchText}
           onChange={setSearchText}

--- a/src/features/search/components/search-bar/media-type-field.tsx
+++ b/src/features/search/components/search-bar/media-type-field.tsx
@@ -6,19 +6,16 @@ import {
   VideoIcon,
   WaveformIcon,
 } from '@phosphor-icons/react/dist/ssr'
-import {
-  Button,
-  Label,
-  ListBox,
-  ListBoxItem,
-  Popover,
-  Select,
-  SelectValue,
-  // purposely using ReactAria's Button to avoid hydration errors
-  Text,
-} from 'react-aria-components'
-import type { Key, SelectProps } from 'react-aria-components'
+// purposely using ReactAria's Button to avoid hydration errors (see below)
+// eslint-disable-next-line no-restricted-imports
+import { Button } from 'react-aria-components'
+import type { SelectKey, SelectProps } from '@/components/ui/select'
 import type { EyepieceMedia } from '@/lib/api/eyepiece/types'
+import { ListBox, ListBoxItem } from '@/components/ui/list-box'
+import { Popover } from '@/components/ui/popover'
+import { Label } from '@/components/ui/forms'
+import { Select, SelectValue } from '@/components/ui/select'
+import { Text } from '@/components/ui/text'
 
 export const ALL_MEDIA = 'all'
 
@@ -36,7 +33,7 @@ export const MEDIA_TYPES: Array<MediaTypeOption> = [
 ]
 
 export function getMediaTypeOption(
-  key: Key | null | undefined,
+  key: SelectKey | null | undefined,
 ): MediaTypeOption | undefined {
   return MEDIA_TYPES.find((option) => option.id === key)
 }

--- a/src/features/search/components/search-bar/search-input.tsx
+++ b/src/features/search/components/search-bar/search-input.tsx
@@ -1,15 +1,12 @@
 import { XIcon } from '@phosphor-icons/react/dist/ssr'
-import {
-  Button,
-  FieldError,
-  Input,
-  SearchField as ReactAriaSearchField,
-} from 'react-aria-components'
-import type { SearchFieldProps } from 'react-aria-components'
+import type { SearchFieldProps } from '@/components/ui/search-field'
+import { FieldError, Input } from '@/components/ui/forms'
+import { SearchField } from '@/components/ui/search-field'
+import { Button } from '@/components/ui/button'
 
-export function SearchField(props: SearchFieldProps) {
+export function SearchInput(props: SearchFieldProps) {
   return (
-    <ReactAriaSearchField
+    <SearchField
       {...props}
       css={{
         display: 'inline-flex',
@@ -38,11 +35,8 @@ export function SearchField(props: SearchFieldProps) {
       />
       <Button
         css={{
-          border: 0,
           background: 'transparent',
           color: 'var(--primary-text)',
-          display: 'inline-flex',
-          alignItems: 'center',
           fontSize: '1em',
           visibility: props.value ? 'visible' : 'hidden',
         }}
@@ -50,6 +44,6 @@ export function SearchField(props: SearchFieldProps) {
         <XIcon />
       </Button>
       <FieldError>Please enter valid search keywords.</FieldError>
-    </ReactAriaSearchField>
+    </SearchField>
   )
 }

--- a/src/features/search/components/search-bar/submit-button.tsx
+++ b/src/features/search/components/search-bar/submit-button.tsx
@@ -1,20 +1,16 @@
 import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
-import { Button } from 'react-aria-components'
-import type { ButtonProps } from 'react-aria-components'
+import type { ButtonProps } from '@/components/ui/button'
+import { Button } from '@/components/ui/button'
 
 export function SubmitButton(props: ButtonProps) {
   return (
     <Button
       type="submit"
       aria-label="Search"
+      variant="primary"
       css={{
         background: 'transparent',
-        border: 0,
-        display: 'inline-flex',
-        alignItems: 'center',
         fontSize: '1em',
-        color: 'var(--primary-text)',
-        '&[data-disabled]': { color: 'var(--primary-text-muted)' },
       }}
       {...props}
     >

--- a/src/features/search/components/search-bar/year-range-slider.tsx
+++ b/src/features/search/components/search-bar/year-range-slider.tsx
@@ -1,12 +1,12 @@
 import { CircleIcon } from '@phosphor-icons/react/dist/ssr'
+import type { SliderProps } from '@/components/ui/slider'
+import { Label } from '@/components/ui/forms'
 import {
-  Label,
   Slider,
   SliderOutput,
   SliderThumb,
   SliderTrack,
-} from 'react-aria-components'
-import type { SliderProps } from 'react-aria-components'
+} from '@/components/ui/slider'
 
 const Thumb = ({
   name,

--- a/src/routes/(pages)/assets/-components/metadata/modal.tsx
+++ b/src/routes/(pages)/assets/-components/metadata/modal.tsx
@@ -1,5 +1,5 @@
-import { Button } from 'react-aria-components'
 import type { ComponentPropsWithoutRef } from 'react'
+import { Button } from '@/components/ui/button'
 import { MetadataTable } from '@/features/assets/components/metadata'
 import { useMetadata } from '@/features/assets/api/asset-queries'
 import { ModalDialog } from '@/components/ui/modal-dialog'


### PR DESCRIPTION
- Always use project ui components, not react aria directly
- Import ui components using @/* prefix
- use react aria's useId instead of the regular react useId
- Fix all usage, adding re-exports to components/ui as needed