### PR TITLE
feat(api): version internal API routes under /api/v1

### DIFF
--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -83,10 +83,10 @@ The provider flow is consistent across search and detail pages:
 
 The main provider-aware API routes are:
 
-- `src/routes/api/search.ts`
-- `src/routes/api/asset/$providerId.$assetId.ts`
-- `src/routes/api/asset/$providerId.$assetId.metadata.ts`
-- `src/routes/api/albums/$providerId.$albumId.ts`
+- `src/routes/api/v1/search.ts`
+- `src/routes/api/v1/asset/$providerId.$assetId.ts`
+- `src/routes/api/v1/asset/$providerId.$assetId.metadata.ts`
+- `src/routes/api/v1/albums/$providerId.$albumId.ts`
 
 ## Search
 
@@ -105,7 +105,7 @@ Current filter schemas live in:
 
 ### Search API
 
-`src/routes/api/search.ts` accepts query text, pagination, and provider-specific filter params. The route normalizes those values into the shared `SearchFilters` shape before calling the provider service.
+`src/routes/api/v1/search.ts` accepts query text, pagination, and provider-specific filter params. The route normalizes those values into the shared `SearchFilters` shape before calling the provider service.
 
 This keeps the public API consistent while still allowing each provider to define its own filter surface.
 
@@ -161,7 +161,7 @@ Adding a provider is mostly a matter of updating the provider-specific seams tha
 1. Add the new provider ID to `src/domain/provider/provider.schema.ts`.
 2. Add a provider-specific search filters schema under `src/domain/search/providers/`.
 3. Extend `searchFiltersSchema` in `src/domain/search/search.schema.ts`.
-4. Update `src/routes/api/search.ts` so query params can be parsed for the new provider.
+4. Update `src/routes/api/v1/search.ts` so query params can be parsed for the new provider.
 5. Implement a new adapter under `src/server/eyepiece/providers/<provider>/` that satisfies `BaseProvider` and any optional capabilities it supports.
 6. Add or reuse an upstream integration client under `src/integrations/<provider>/`.
 7. Register the adapter in `src/server/eyepiece/service.ts`.
@@ -206,7 +206,7 @@ For most provider changes, these are the files to inspect first:
 
 - `src/domain/provider/provider.schema.ts`
 - `src/domain/search/search.schema.ts`
-- `src/routes/api/search.ts`
+- `src/routes/api/v1/search.ts`
 - `src/server/eyepiece/provider.ts`
 - `src/server/eyepiece/service.ts`
 - `src/server/eyepiece/providers/`

--- a/src/lib/api-paths.ts
+++ b/src/lib/api-paths.ts
@@ -1,0 +1,35 @@
+/**
+ * Centralized internal eyepiece API path definitions.
+ *
+ * `V1_ROUTE_PATHS` — static route pattern strings for use in `createFileRoute`
+ * declarations and observability tags.
+ *
+ * `buildXxxUrl` functions — URL builders for the internal API client; they
+ * percent-encode path segments so callers never need to do it themselves.
+ */
+
+const API_V1_PREFIX = '/api/v1' as const
+
+export const V1_ROUTE_PATHS = {
+  search: `${API_V1_PREFIX}/search`,
+  asset: `${API_V1_PREFIX}/asset/$providerId/$assetId`,
+  assetMetadata: `${API_V1_PREFIX}/asset/$providerId/$assetId/metadata`,
+  album: `${API_V1_PREFIX}/albums/$providerId/$albumId`,
+} as const
+
+export function buildAssetUrl(providerId: string, externalId: string): string {
+  return `${API_V1_PREFIX}/asset/${encodeURIComponent(providerId)}/${encodeURIComponent(externalId)}`
+}
+
+export function buildAssetMetadataUrl(
+  providerId: string,
+  externalId: string,
+): string {
+  return `${API_V1_PREFIX}/asset/${encodeURIComponent(providerId)}/${encodeURIComponent(externalId)}/metadata`
+}
+
+export function buildAlbumUrl(providerId: string, externalId: string): string {
+  return `${API_V1_PREFIX}/albums/${encodeURIComponent(providerId)}/${encodeURIComponent(externalId)}`
+}
+
+export const SEARCH_URL = `${API_V1_PREFIX}/search` as const

--- a/src/lib/eyepiece-api-client/client.ts
+++ b/src/lib/eyepiece-api-client/client.ts
@@ -7,6 +7,12 @@ import type {
   Pagination,
 } from '@/domain/pagination/pagination.schema'
 import type { SearchFilters, SearchQuery } from '@/domain/search/search.schema'
+import {
+  SEARCH_URL,
+  buildAlbumUrl,
+  buildAssetMetadataUrl,
+  buildAssetUrl,
+} from '@/lib/api-paths'
 import { createPaginatedCollectionSchema } from '@/domain/pagination/pagination.schema'
 import { assetSchema, metadataSchema } from '@/domain/asset/asset.schema'
 
@@ -89,7 +95,7 @@ export function createEyepieceClient({
     getAlbum: async function getAlbum(key: AlbumKey, pagination: Pagination) {
       const res = await fetch(
         withOrigin(
-          `/api/albums/${encodeURIComponent(key.providerId)}/${encodeURIComponent(key.externalId)}${defaultStringifySearch(pagination)}`,
+          `${buildAlbumUrl(key.providerId, key.externalId)}${defaultStringifySearch(pagination)}`,
         ),
       )
       if (!res.ok) {
@@ -101,9 +107,7 @@ export function createEyepieceClient({
 
     getAsset: async function getAsset(key: AssetKey) {
       const res = await fetch(
-        withOrigin(
-          `/api/asset/${encodeURIComponent(key.providerId)}/${encodeURIComponent(key.externalId)}`,
-        ),
+        withOrigin(buildAssetUrl(key.providerId, key.externalId)),
       )
       if (!res.ok) {
         await throwApiClientError('Error fetching asset', res)
@@ -114,9 +118,7 @@ export function createEyepieceClient({
 
     getMetadata: async function getMetadata(key: AssetKey) {
       const res = await fetch(
-        withOrigin(
-          `/api/asset/${encodeURIComponent(key.providerId)}/${encodeURIComponent(key.externalId)}/metadata`,
-        ),
+        withOrigin(buildAssetMetadataUrl(key.providerId, key.externalId)),
       )
       if (!res.ok) {
         await throwApiClientError('Error fetching asset metadata', res)
@@ -132,7 +134,7 @@ export function createEyepieceClient({
     ) {
       const res = await fetch(
         withOrigin(
-          `/api/search${defaultStringifySearch({ providerId: filters.providerId, q: query, ...filters.filters, ...pagination })}`,
+          `${SEARCH_URL}${defaultStringifySearch({ providerId: filters.providerId, q: query, ...filters.filters, ...pagination })}`,
         ),
       )
       if (!res.ok) {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,7 +15,6 @@ import { Route as pagesRouteRouteImport } from './routes/(pages)/route'
 import { Route as authRouteRouteImport } from './routes/(auth)/route'
 import { Route as DevIndexRouteImport } from './routes/dev/index'
 import { Route as pagesIndexRouteImport } from './routes/(pages)/index'
-import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as pagesButtonsRouteImport } from './routes/(pages)/buttons'
 import { Route as authRegisterRouteImport } from './routes/(auth)/register'
 import { Route as authLoginRouteImport } from './routes/(auth)/login'
@@ -28,6 +27,7 @@ import { Route as DevUiFeedbackRouteImport } from './routes/dev/ui/feedback'
 import { Route as DevUiControlsRouteImport } from './routes/dev/ui/controls'
 import { Route as DevObservabilityServerErrorRouteImport } from './routes/dev/observability/server-error'
 import { Route as DevObservabilityHandled400RouteImport } from './routes/dev/observability/handled-400'
+import { Route as ApiV1SearchRouteImport } from './routes/api/v1/search'
 import { Route as pagesProfileProfileIdRouteImport } from './routes/(pages)/profile.$profileId'
 import { Route as pagesuserFavoritesRouteImport } from './routes/(pages)/(user)/favorites'
 import { Route as pagessearchSearchRouteImport } from './routes/(pages)/(search)/search'
@@ -36,12 +36,12 @@ import { Route as authAuthForgotPasswordRouteImport } from './routes/(auth)/auth
 import { Route as authAuthConfirmErrorRouteImport } from './routes/(auth)/auth/confirm-error'
 import { Route as authAuthConfirmRouteImport } from './routes/(auth)/auth/confirm'
 import { Route as pagesuserSettingsIndexRouteImport } from './routes/(pages)/(user)/settings/index'
-import { Route as ApiAssetProviderIdAssetIdRouteImport } from './routes/api/asset/$providerId.$assetId'
-import { Route as ApiAlbumsProviderIdAlbumIdRouteImport } from './routes/api/albums/$providerId.$albumId'
 import { Route as pagesAssetsProviderIdAssetIdRouteImport } from './routes/(pages)/assets/$providerId.$assetId'
 import { Route as pagesAlbumsProviderIdAlbumIdRouteImport } from './routes/(pages)/albums/$providerId.$albumId'
 import { Route as pagesuserSettingsProfileRouteImport } from './routes/(pages)/(user)/settings/profile'
-import { Route as ApiAssetProviderIdAssetIdMetadataRouteImport } from './routes/api/asset/$providerId.$assetId.metadata'
+import { Route as ApiV1AssetProviderIdAssetIdRouteImport } from './routes/api/v1/asset/$providerId.$assetId'
+import { Route as ApiV1AlbumsProviderIdAlbumIdRouteImport } from './routes/api/v1/albums/$providerId.$albumId'
+import { Route as ApiV1AssetProviderIdAssetIdMetadataRouteImport } from './routes/api/v1/asset/$providerId.$assetId.metadata'
 
 const CompleteProfileRoute = CompleteProfileRouteImport.update({
   id: '/complete-profile',
@@ -70,11 +70,6 @@ const pagesIndexRoute = pagesIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => pagesRouteRoute,
-} as any)
-const ApiSearchRoute = ApiSearchRouteImport.update({
-  id: '/api/search',
-  path: '/api/search',
-  getParentRoute: () => rootRouteImport,
 } as any)
 const pagesButtonsRoute = pagesButtonsRouteImport.update({
   id: '/buttons',
@@ -137,6 +132,11 @@ const DevObservabilityHandled400Route =
     path: '/handled-400',
     getParentRoute: () => DevObservabilityRouteRoute,
   } as any)
+const ApiV1SearchRoute = ApiV1SearchRouteImport.update({
+  id: '/api/v1/search',
+  path: '/api/v1/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const pagesProfileProfileIdRoute = pagesProfileProfileIdRouteImport.update({
   id: '/profile/$profileId',
   path: '/profile/$profileId',
@@ -177,18 +177,6 @@ const pagesuserSettingsIndexRoute = pagesuserSettingsIndexRouteImport.update({
   path: '/settings/',
   getParentRoute: () => pagesuserRouteRoute,
 } as any)
-const ApiAssetProviderIdAssetIdRoute =
-  ApiAssetProviderIdAssetIdRouteImport.update({
-    id: '/api/asset/$providerId/$assetId',
-    path: '/api/asset/$providerId/$assetId',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ApiAlbumsProviderIdAlbumIdRoute =
-  ApiAlbumsProviderIdAlbumIdRouteImport.update({
-    id: '/api/albums/$providerId/$albumId',
-    path: '/api/albums/$providerId/$albumId',
-    getParentRoute: () => rootRouteImport,
-  } as any)
 const pagesAssetsProviderIdAssetIdRoute =
   pagesAssetsProviderIdAssetIdRouteImport.update({
     id: '/assets/$providerId/$assetId',
@@ -207,11 +195,23 @@ const pagesuserSettingsProfileRoute =
     path: '/settings/profile',
     getParentRoute: () => pagesuserRouteRoute,
   } as any)
-const ApiAssetProviderIdAssetIdMetadataRoute =
-  ApiAssetProviderIdAssetIdMetadataRouteImport.update({
+const ApiV1AssetProviderIdAssetIdRoute =
+  ApiV1AssetProviderIdAssetIdRouteImport.update({
+    id: '/api/v1/asset/$providerId/$assetId',
+    path: '/api/v1/asset/$providerId/$assetId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1AlbumsProviderIdAlbumIdRoute =
+  ApiV1AlbumsProviderIdAlbumIdRouteImport.update({
+    id: '/api/v1/albums/$providerId/$albumId',
+    path: '/api/v1/albums/$providerId/$albumId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1AssetProviderIdAssetIdMetadataRoute =
+  ApiV1AssetProviderIdAssetIdMetadataRouteImport.update({
     id: '/metadata',
     path: '/metadata',
-    getParentRoute: () => ApiAssetProviderIdAssetIdRoute,
+    getParentRoute: () => ApiV1AssetProviderIdAssetIdRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -222,7 +222,6 @@ export interface FileRoutesByFullPath {
   '/login': typeof authLoginRoute
   '/register': typeof authRegisterRoute
   '/buttons': typeof pagesButtonsRoute
-  '/api/search': typeof ApiSearchRoute
   '/': typeof pagesIndexRoute
   '/dev/': typeof DevIndexRoute
   '/auth/confirm': typeof authAuthConfirmRoute
@@ -232,6 +231,7 @@ export interface FileRoutesByFullPath {
   '/search': typeof pagessearchSearchRoute
   '/favorites': typeof pagesuserFavoritesRoute
   '/profile/$profileId': typeof pagesProfileProfileIdRoute
+  '/api/v1/search': typeof ApiV1SearchRoute
   '/dev/observability/handled-400': typeof DevObservabilityHandled400Route
   '/dev/observability/server-error': typeof DevObservabilityServerErrorRoute
   '/dev/ui/controls': typeof DevUiControlsRoute
@@ -241,17 +241,16 @@ export interface FileRoutesByFullPath {
   '/settings/profile': typeof pagesuserSettingsProfileRoute
   '/albums/$providerId/$albumId': typeof pagesAlbumsProviderIdAlbumIdRoute
   '/assets/$providerId/$assetId': typeof pagesAssetsProviderIdAssetIdRoute
-  '/api/albums/$providerId/$albumId': typeof ApiAlbumsProviderIdAlbumIdRoute
-  '/api/asset/$providerId/$assetId': typeof ApiAssetProviderIdAssetIdRouteWithChildren
   '/settings/': typeof pagesuserSettingsIndexRoute
-  '/api/asset/$providerId/$assetId/metadata': typeof ApiAssetProviderIdAssetIdMetadataRoute
+  '/api/v1/albums/$providerId/$albumId': typeof ApiV1AlbumsProviderIdAlbumIdRoute
+  '/api/v1/asset/$providerId/$assetId': typeof ApiV1AssetProviderIdAssetIdRouteWithChildren
+  '/api/v1/asset/$providerId/$assetId/metadata': typeof ApiV1AssetProviderIdAssetIdMetadataRoute
 }
 export interface FileRoutesByTo {
   '/complete-profile': typeof CompleteProfileRoute
   '/login': typeof authLoginRoute
   '/register': typeof authRegisterRoute
   '/buttons': typeof pagesButtonsRoute
-  '/api/search': typeof ApiSearchRoute
   '/': typeof pagesIndexRoute
   '/dev': typeof DevIndexRoute
   '/auth/confirm': typeof authAuthConfirmRoute
@@ -261,6 +260,7 @@ export interface FileRoutesByTo {
   '/search': typeof pagessearchSearchRoute
   '/favorites': typeof pagesuserFavoritesRoute
   '/profile/$profileId': typeof pagesProfileProfileIdRoute
+  '/api/v1/search': typeof ApiV1SearchRoute
   '/dev/observability/handled-400': typeof DevObservabilityHandled400Route
   '/dev/observability/server-error': typeof DevObservabilityServerErrorRoute
   '/dev/ui/controls': typeof DevUiControlsRoute
@@ -270,10 +270,10 @@ export interface FileRoutesByTo {
   '/settings/profile': typeof pagesuserSettingsProfileRoute
   '/albums/$providerId/$albumId': typeof pagesAlbumsProviderIdAlbumIdRoute
   '/assets/$providerId/$assetId': typeof pagesAssetsProviderIdAssetIdRoute
-  '/api/albums/$providerId/$albumId': typeof ApiAlbumsProviderIdAlbumIdRoute
-  '/api/asset/$providerId/$assetId': typeof ApiAssetProviderIdAssetIdRouteWithChildren
   '/settings': typeof pagesuserSettingsIndexRoute
-  '/api/asset/$providerId/$assetId/metadata': typeof ApiAssetProviderIdAssetIdMetadataRoute
+  '/api/v1/albums/$providerId/$albumId': typeof ApiV1AlbumsProviderIdAlbumIdRoute
+  '/api/v1/asset/$providerId/$assetId': typeof ApiV1AssetProviderIdAssetIdRouteWithChildren
+  '/api/v1/asset/$providerId/$assetId/metadata': typeof ApiV1AssetProviderIdAssetIdMetadataRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -287,7 +287,6 @@ export interface FileRoutesById {
   '/(auth)/login': typeof authLoginRoute
   '/(auth)/register': typeof authRegisterRoute
   '/(pages)/buttons': typeof pagesButtonsRoute
-  '/api/search': typeof ApiSearchRoute
   '/(pages)/': typeof pagesIndexRoute
   '/dev/': typeof DevIndexRoute
   '/(auth)/auth/confirm': typeof authAuthConfirmRoute
@@ -297,6 +296,7 @@ export interface FileRoutesById {
   '/(pages)/(search)/search': typeof pagessearchSearchRoute
   '/(pages)/(user)/favorites': typeof pagesuserFavoritesRoute
   '/(pages)/profile/$profileId': typeof pagesProfileProfileIdRoute
+  '/api/v1/search': typeof ApiV1SearchRoute
   '/dev/observability/handled-400': typeof DevObservabilityHandled400Route
   '/dev/observability/server-error': typeof DevObservabilityServerErrorRoute
   '/dev/ui/controls': typeof DevUiControlsRoute
@@ -306,10 +306,10 @@ export interface FileRoutesById {
   '/(pages)/(user)/settings/profile': typeof pagesuserSettingsProfileRoute
   '/(pages)/albums/$providerId/$albumId': typeof pagesAlbumsProviderIdAlbumIdRoute
   '/(pages)/assets/$providerId/$assetId': typeof pagesAssetsProviderIdAssetIdRoute
-  '/api/albums/$providerId/$albumId': typeof ApiAlbumsProviderIdAlbumIdRoute
-  '/api/asset/$providerId/$assetId': typeof ApiAssetProviderIdAssetIdRouteWithChildren
   '/(pages)/(user)/settings/': typeof pagesuserSettingsIndexRoute
-  '/api/asset/$providerId/$assetId/metadata': typeof ApiAssetProviderIdAssetIdMetadataRoute
+  '/api/v1/albums/$providerId/$albumId': typeof ApiV1AlbumsProviderIdAlbumIdRoute
+  '/api/v1/asset/$providerId/$assetId': typeof ApiV1AssetProviderIdAssetIdRouteWithChildren
+  '/api/v1/asset/$providerId/$assetId/metadata': typeof ApiV1AssetProviderIdAssetIdMetadataRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -321,7 +321,6 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/buttons'
-    | '/api/search'
     | '/'
     | '/dev/'
     | '/auth/confirm'
@@ -331,6 +330,7 @@ export interface FileRouteTypes {
     | '/search'
     | '/favorites'
     | '/profile/$profileId'
+    | '/api/v1/search'
     | '/dev/observability/handled-400'
     | '/dev/observability/server-error'
     | '/dev/ui/controls'
@@ -340,17 +340,16 @@ export interface FileRouteTypes {
     | '/settings/profile'
     | '/albums/$providerId/$albumId'
     | '/assets/$providerId/$assetId'
-    | '/api/albums/$providerId/$albumId'
-    | '/api/asset/$providerId/$assetId'
     | '/settings/'
-    | '/api/asset/$providerId/$assetId/metadata'
+    | '/api/v1/albums/$providerId/$albumId'
+    | '/api/v1/asset/$providerId/$assetId'
+    | '/api/v1/asset/$providerId/$assetId/metadata'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/complete-profile'
     | '/login'
     | '/register'
     | '/buttons'
-    | '/api/search'
     | '/'
     | '/dev'
     | '/auth/confirm'
@@ -360,6 +359,7 @@ export interface FileRouteTypes {
     | '/search'
     | '/favorites'
     | '/profile/$profileId'
+    | '/api/v1/search'
     | '/dev/observability/handled-400'
     | '/dev/observability/server-error'
     | '/dev/ui/controls'
@@ -369,10 +369,10 @@ export interface FileRouteTypes {
     | '/settings/profile'
     | '/albums/$providerId/$albumId'
     | '/assets/$providerId/$assetId'
-    | '/api/albums/$providerId/$albumId'
-    | '/api/asset/$providerId/$assetId'
     | '/settings'
-    | '/api/asset/$providerId/$assetId/metadata'
+    | '/api/v1/albums/$providerId/$albumId'
+    | '/api/v1/asset/$providerId/$assetId'
+    | '/api/v1/asset/$providerId/$assetId/metadata'
   id:
     | '__root__'
     | '/(auth)'
@@ -385,7 +385,6 @@ export interface FileRouteTypes {
     | '/(auth)/login'
     | '/(auth)/register'
     | '/(pages)/buttons'
-    | '/api/search'
     | '/(pages)/'
     | '/dev/'
     | '/(auth)/auth/confirm'
@@ -395,6 +394,7 @@ export interface FileRouteTypes {
     | '/(pages)/(search)/search'
     | '/(pages)/(user)/favorites'
     | '/(pages)/profile/$profileId'
+    | '/api/v1/search'
     | '/dev/observability/handled-400'
     | '/dev/observability/server-error'
     | '/dev/ui/controls'
@@ -404,10 +404,10 @@ export interface FileRouteTypes {
     | '/(pages)/(user)/settings/profile'
     | '/(pages)/albums/$providerId/$albumId'
     | '/(pages)/assets/$providerId/$assetId'
-    | '/api/albums/$providerId/$albumId'
-    | '/api/asset/$providerId/$assetId'
     | '/(pages)/(user)/settings/'
-    | '/api/asset/$providerId/$assetId/metadata'
+    | '/api/v1/albums/$providerId/$albumId'
+    | '/api/v1/asset/$providerId/$assetId'
+    | '/api/v1/asset/$providerId/$assetId/metadata'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -415,9 +415,9 @@ export interface RootRouteChildren {
   pagesRouteRoute: typeof pagesRouteRouteWithChildren
   DevRouteRoute: typeof DevRouteRouteWithChildren
   CompleteProfileRoute: typeof CompleteProfileRoute
-  ApiSearchRoute: typeof ApiSearchRoute
-  ApiAlbumsProviderIdAlbumIdRoute: typeof ApiAlbumsProviderIdAlbumIdRoute
-  ApiAssetProviderIdAssetIdRoute: typeof ApiAssetProviderIdAssetIdRouteWithChildren
+  ApiV1SearchRoute: typeof ApiV1SearchRoute
+  ApiV1AlbumsProviderIdAlbumIdRoute: typeof ApiV1AlbumsProviderIdAlbumIdRoute
+  ApiV1AssetProviderIdAssetIdRoute: typeof ApiV1AssetProviderIdAssetIdRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
@@ -463,13 +463,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof pagesIndexRouteImport
       parentRoute: typeof pagesRouteRoute
-    }
-    '/api/search': {
-      id: '/api/search'
-      path: '/api/search'
-      fullPath: '/api/search'
-      preLoaderRoute: typeof ApiSearchRouteImport
-      parentRoute: typeof rootRouteImport
     }
     '/(pages)/buttons': {
       id: '/(pages)/buttons'
@@ -555,6 +548,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DevObservabilityHandled400RouteImport
       parentRoute: typeof DevObservabilityRouteRoute
     }
+    '/api/v1/search': {
+      id: '/api/v1/search'
+      path: '/api/v1/search'
+      fullPath: '/api/v1/search'
+      preLoaderRoute: typeof ApiV1SearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/(pages)/profile/$profileId': {
       id: '/(pages)/profile/$profileId'
       path: '/profile/$profileId'
@@ -611,20 +611,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof pagesuserSettingsIndexRouteImport
       parentRoute: typeof pagesuserRouteRoute
     }
-    '/api/asset/$providerId/$assetId': {
-      id: '/api/asset/$providerId/$assetId'
-      path: '/api/asset/$providerId/$assetId'
-      fullPath: '/api/asset/$providerId/$assetId'
-      preLoaderRoute: typeof ApiAssetProviderIdAssetIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/albums/$providerId/$albumId': {
-      id: '/api/albums/$providerId/$albumId'
-      path: '/api/albums/$providerId/$albumId'
-      fullPath: '/api/albums/$providerId/$albumId'
-      preLoaderRoute: typeof ApiAlbumsProviderIdAlbumIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/(pages)/assets/$providerId/$assetId': {
       id: '/(pages)/assets/$providerId/$assetId'
       path: '/assets/$providerId/$assetId'
@@ -646,12 +632,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof pagesuserSettingsProfileRouteImport
       parentRoute: typeof pagesuserRouteRoute
     }
-    '/api/asset/$providerId/$assetId/metadata': {
-      id: '/api/asset/$providerId/$assetId/metadata'
+    '/api/v1/asset/$providerId/$assetId': {
+      id: '/api/v1/asset/$providerId/$assetId'
+      path: '/api/v1/asset/$providerId/$assetId'
+      fullPath: '/api/v1/asset/$providerId/$assetId'
+      preLoaderRoute: typeof ApiV1AssetProviderIdAssetIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/albums/$providerId/$albumId': {
+      id: '/api/v1/albums/$providerId/$albumId'
+      path: '/api/v1/albums/$providerId/$albumId'
+      fullPath: '/api/v1/albums/$providerId/$albumId'
+      preLoaderRoute: typeof ApiV1AlbumsProviderIdAlbumIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/asset/$providerId/$assetId/metadata': {
+      id: '/api/v1/asset/$providerId/$assetId/metadata'
       path: '/metadata'
-      fullPath: '/api/asset/$providerId/$assetId/metadata'
-      preLoaderRoute: typeof ApiAssetProviderIdAssetIdMetadataRouteImport
-      parentRoute: typeof ApiAssetProviderIdAssetIdRoute
+      fullPath: '/api/v1/asset/$providerId/$assetId/metadata'
+      preLoaderRoute: typeof ApiV1AssetProviderIdAssetIdMetadataRouteImport
+      parentRoute: typeof ApiV1AssetProviderIdAssetIdRoute
     }
   }
 }
@@ -767,19 +767,19 @@ const DevRouteRouteWithChildren = DevRouteRoute._addFileChildren(
   DevRouteRouteChildren,
 )
 
-interface ApiAssetProviderIdAssetIdRouteChildren {
-  ApiAssetProviderIdAssetIdMetadataRoute: typeof ApiAssetProviderIdAssetIdMetadataRoute
+interface ApiV1AssetProviderIdAssetIdRouteChildren {
+  ApiV1AssetProviderIdAssetIdMetadataRoute: typeof ApiV1AssetProviderIdAssetIdMetadataRoute
 }
 
-const ApiAssetProviderIdAssetIdRouteChildren: ApiAssetProviderIdAssetIdRouteChildren =
+const ApiV1AssetProviderIdAssetIdRouteChildren: ApiV1AssetProviderIdAssetIdRouteChildren =
   {
-    ApiAssetProviderIdAssetIdMetadataRoute:
-      ApiAssetProviderIdAssetIdMetadataRoute,
+    ApiV1AssetProviderIdAssetIdMetadataRoute:
+      ApiV1AssetProviderIdAssetIdMetadataRoute,
   }
 
-const ApiAssetProviderIdAssetIdRouteWithChildren =
-  ApiAssetProviderIdAssetIdRoute._addFileChildren(
-    ApiAssetProviderIdAssetIdRouteChildren,
+const ApiV1AssetProviderIdAssetIdRouteWithChildren =
+  ApiV1AssetProviderIdAssetIdRoute._addFileChildren(
+    ApiV1AssetProviderIdAssetIdRouteChildren,
   )
 
 const rootRouteChildren: RootRouteChildren = {
@@ -787,9 +787,10 @@ const rootRouteChildren: RootRouteChildren = {
   pagesRouteRoute: pagesRouteRouteWithChildren,
   DevRouteRoute: DevRouteRouteWithChildren,
   CompleteProfileRoute: CompleteProfileRoute,
-  ApiSearchRoute: ApiSearchRoute,
-  ApiAlbumsProviderIdAlbumIdRoute: ApiAlbumsProviderIdAlbumIdRoute,
-  ApiAssetProviderIdAssetIdRoute: ApiAssetProviderIdAssetIdRouteWithChildren,
+  ApiV1SearchRoute: ApiV1SearchRoute,
+  ApiV1AlbumsProviderIdAlbumIdRoute: ApiV1AlbumsProviderIdAlbumIdRoute,
+  ApiV1AssetProviderIdAssetIdRoute:
+    ApiV1AssetProviderIdAssetIdRouteWithChildren,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/v1/albums/$providerId.$albumId.ts
+++ b/src/routes/api/v1/albums/$providerId.$albumId.ts
@@ -15,10 +15,11 @@ import {
   parseOrThrowProviderId,
 } from '@/server/lib/utils'
 import { externalAlbumIdSchema } from '@/domain/album/album.schema'
+import { V1_ROUTE_PATHS } from '@/lib/api-paths'
 
 const searchParamsMiddleware = buildUrlSearchParamsMiddleware(paginationSchema)
 
-export const Route = createFileRoute('/api/albums/$providerId/$albumId')({
+export const Route = createFileRoute('/api/v1/albums/$providerId/$albumId')({
   server: {
     middleware: [searchParamsMiddleware],
     handlers: {
@@ -55,7 +56,7 @@ export const Route = createFileRoute('/api/albums/$providerId/$albumId')({
 
           rethrowHandledErrorWithContext(error, {
             tags: {
-              'api.route': '/api/albums/$providerId/$albumId',
+              'api.route': V1_ROUTE_PATHS.album,
               'http.method': 'GET',
             },
           })

--- a/src/routes/api/v1/albums/$providerId.$albumId.unit.test.ts
+++ b/src/routes/api/v1/albums/$providerId.$albumId.unit.test.ts
@@ -76,7 +76,7 @@ async function expectBadRequest(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('GET /api/albums/:providerId/:albumId handler', () => {
+describe('GET /api/v1/albums/:providerId/:albumId handler', () => {
   beforeEach(() => {
     mockService.getAlbum.mockReset()
     mockService.getAlbum.mockResolvedValue(firstPage)

--- a/src/routes/api/v1/asset/$providerId.$assetId.metadata.ts
+++ b/src/routes/api/v1/asset/$providerId.$assetId.metadata.ts
@@ -9,9 +9,10 @@ import {
   rethrowHandledErrorWithContext,
 } from '@/server/lib/handled-errors'
 import { parseOrThrowProviderId } from '@/server/lib/utils'
+import { V1_ROUTE_PATHS } from '@/lib/api-paths'
 
 export const Route = createFileRoute(
-  '/api/asset/$providerId/$assetId/metadata',
+  '/api/v1/asset/$providerId/$assetId/metadata',
 )({
   server: {
     handlers: {
@@ -36,7 +37,7 @@ export const Route = createFileRoute(
 
           rethrowHandledErrorWithContext(error, {
             tags: {
-              'api.route': '/api/asset/$providerId/$assetId/metadata',
+              'api.route': V1_ROUTE_PATHS.assetMetadata,
               'http.method': 'GET',
             },
           })

--- a/src/routes/api/v1/asset/$providerId.$assetId.ts
+++ b/src/routes/api/v1/asset/$providerId.$assetId.ts
@@ -3,8 +3,9 @@ import { makeEyepieceProviderService } from '@/server/eyepiece/service'
 import { createNotFoundResponse } from '@/server/lib/api-errors'
 import { rethrowHandledErrorWithContext } from '@/server/lib/handled-errors'
 import { parseOrThrowProviderId } from '@/server/lib/utils'
+import { V1_ROUTE_PATHS } from '@/lib/api-paths'
 
-export const Route = createFileRoute('/api/asset/$providerId/$assetId')({
+export const Route = createFileRoute('/api/v1/asset/$providerId/$assetId')({
   server: {
     handlers: {
       GET: async ({ params: { providerId: providerIdString, assetId } }) => {
@@ -20,7 +21,7 @@ export const Route = createFileRoute('/api/asset/$providerId/$assetId')({
         } catch (error) {
           rethrowHandledErrorWithContext(error, {
             tags: {
-              'api.route': '/api/asset/$providerId/$assetId',
+              'api.route': V1_ROUTE_PATHS.asset,
               'http.method': 'GET',
             },
           })

--- a/src/routes/api/v1/asset/$providerId.$assetId.unit.test.ts
+++ b/src/routes/api/v1/asset/$providerId.$assetId.unit.test.ts
@@ -122,10 +122,10 @@ async function expectBadRequest(
 }
 
 // ---------------------------------------------------------------------------
-// GET /api/asset/:providerId/:assetId
+// GET /api/v1/asset/:providerId/:assetId
 // ---------------------------------------------------------------------------
 
-describe('GET /api/asset/:providerId/:assetId handler', () => {
+describe('GET /api/v1/asset/:providerId/:assetId handler', () => {
   beforeEach(() => {
     mockService.getAsset.mockReset()
     mockService.getAsset.mockResolvedValue(mockAsset)
@@ -259,7 +259,7 @@ describe('GET /api/asset/:providerId/:assetId handler', () => {
             feature: 'providers',
             operation: 'asset.fetch',
             'provider.id': NASA_IVL_PROVIDER_ID,
-            'api.route': '/api/asset/$providerId/$assetId',
+            'api.route': '/api/v1/asset/$providerId/$assetId',
             'http.method': 'GET',
           },
         },
@@ -269,10 +269,10 @@ describe('GET /api/asset/:providerId/:assetId handler', () => {
 })
 
 // ---------------------------------------------------------------------------
-// GET /api/asset/:providerId/:assetId/metadata
+// GET /api/v1/asset/:providerId/:assetId/metadata
 // ---------------------------------------------------------------------------
 
-describe('GET /api/asset/:providerId/:assetId/metadata handler', () => {
+describe('GET /api/v1/asset/:providerId/:assetId/metadata handler', () => {
   beforeEach(() => {
     mockService.getMetadata.mockReset()
     mockService.getMetadata.mockResolvedValue(mockMetadata)

--- a/src/routes/api/v1/search.ts
+++ b/src/routes/api/v1/search.ts
@@ -15,6 +15,7 @@ import {
 } from '@/domain/provider/provider.schema'
 import { nasaIvlSearchFiltersSchema } from '@/domain/search/providers/nasa-ivl-filters'
 import { sioaSearchFiltersSchema } from '@/domain/search/providers/si-oa-filters'
+import { V1_ROUTE_PATHS } from '@/lib/api-paths'
 
 export const searchQueryParamSchema = z.object({
   q: searchQuerySchema,
@@ -34,7 +35,7 @@ const searchParamsMiddleware = buildUrlSearchParamsMiddleware(
 const INVALID_SEARCH_PARAMS_MESSAGE =
   'One or more query parameters are invalid.'
 
-export const Route = createFileRoute('/api/search')({
+export const Route = createFileRoute('/api/v1/search')({
   server: {
     middleware: [searchParamsMiddleware],
     handlers: {
@@ -63,18 +64,15 @@ export const Route = createFileRoute('/api/search')({
             code: 'INVALID_QUERY_PARAMS',
           },
         )
-        const pagination = {
-          page,
-          pageSize,
-        }
+
         let results
 
         try {
-          results = await eyepiece.searchAssets(q, filters, pagination)
+          results = await eyepiece.searchAssets(q, filters, { page, pageSize })
         } catch (error) {
           rethrowHandledErrorWithContext(error, {
             tags: {
-              'api.route': '/api/search',
+              'api.route': V1_ROUTE_PATHS.search,
               'http.method': 'GET',
             },
           })

--- a/src/routes/api/v1/search.unit.test.ts
+++ b/src/routes/api/v1/search.unit.test.ts
@@ -163,7 +163,7 @@ const sioaSearchResults = {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('GET /api/search handler', () => {
+describe('GET /api/v1/search handler', () => {
   beforeEach(() => {
     mockService.searchAssets.mockReset()
     mockService.searchAssets.mockResolvedValue(emptyPage)
@@ -234,7 +234,7 @@ describe('GET /api/search handler', () => {
     await expectBadRequest(
       searchParamsMiddleware({
         request: new Request(
-          'https://example.com/api/search?providerId=nasa_ivl&page=1&pageSize=24&mediaType=image',
+          'https://example.com/api/v1/search?providerId=nasa_ivl&page=1&pageSize=24&mediaType=image',
         ),
         next: vi.fn(),
       }),
@@ -260,7 +260,7 @@ describe('GET /api/search handler', () => {
     await expectBadRequest(
       searchParamsMiddleware({
         request: new Request(
-          'https://example.com/api/search?q=apollo&providerId=not_a_provider&page=1&pageSize=24&mediaType=image',
+          'https://example.com/api/v1/search?q=apollo&providerId=not_a_provider&page=1&pageSize=24&mediaType=image',
         ),
         next,
       }),
@@ -305,7 +305,7 @@ describe('GET /api/search handler', () => {
             feature: 'providers',
             operation: 'search.fetch',
             'provider.id': NASA_IVL_PROVIDER_ID,
-            'api.route': '/api/search',
+            'api.route': '/api/v1/search',
             'http.method': 'GET',
           },
         },


### PR DESCRIPTION
- add src/lib/api-paths.ts as single source of truth for v1 route patterns and URL builder functions
- move all internal API routes to src/routes/api/v1/
- update EyepieceClient to use api-paths builders instead of inline string literals
- update route tests to reflect /api/v1/... paths and tags
- update docs/Providers.md references to new route locations
- regenerate routeTree.gen.ts with v1 paths

Closes #81